### PR TITLE
Add policy for merging codelist changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Unofficial Codelists
 
 [![Build Status](https://travis-ci.com/codeforIATI/Unofficial-Codelists.svg?branch=master)](https://travis-ci.com/codeforIATI/Unofficial-Codelists)
+
+## Policy for merging changes
+
+Any changes should be reviewed before merging.
+
+In the case of an automated PR (provided by `codelist-updater`), the same person can both review and merge the PR, as the PR should only contain changes that keep a codelist in sync with the source.


### PR DESCRIPTION
Adds a brief policy on simplifying the process for merging codelist changes, ref #15